### PR TITLE
Allow not declaring 'negate' in check definitions

### DIFF
--- a/zkPolicy/pom.xml
+++ b/zkPolicy/pom.xml
@@ -85,7 +85,6 @@ or submit itself to any jurisdiction.
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>[2.15.0,)</version>
-      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
 

--- a/zkPolicy/src/main/java/ch/cern/ZKCheckElement.java
+++ b/zkPolicy/src/main/java/ch/cern/ZKCheckElement.java
@@ -44,7 +44,7 @@ public class ZKCheckElement {
    */
   public String generateDescription() {
     StringBuffer outputBuf = new StringBuffer();
-    if (this.negate) {
+    if (this.negate != null && this.negate) {
       outputBuf.append(String.format(ZKPolicyDefs.Check.NEGATE_DESCRIPTION_FORMAT, rootPath, pathPattern) + "\n");
     } else {
       outputBuf.append(String.format(ZKPolicyDefs.Check.DESCRIPTION_FORMAT, rootPath, pathPattern) + "\n");

--- a/zkPolicy/src/test/java/ch/cern/ZKAuditTest.java
+++ b/zkPolicy/src/test/java/ch/cern/ZKAuditTest.java
@@ -284,6 +284,34 @@ public class ZKAuditTest {
   }
 
   @Test
+  public void testNoNodesFoundForPathPatternCheckNoNegate() throws Exception {
+    File file = new File(testTempDir, "audit_tmp.yml");
+
+    FileWriter fw = new FileWriter(file);
+    fw.write("---\n");
+    fw.write("checks:\n");
+    fw.write("  - title: \"Check 1 title\"\n");
+    fw.write("    rootPath: \"/a\"\n");
+    fw.write("    pathPattern: \"/noexistingpattern\"\n");
+    fw.write("    acls:\n");
+    fw.write("      - \"world:anyone:r\"\n");
+
+    fw.flush();
+    fw.close();
+
+    ZKAudit zkAudit = new ZKAudit(this.zkClient, file);
+    assertNotNull(zkAudit);
+
+    String expectedOutput = String.join("\n", "", "Check: Check 1 title", "Root Path: /a",
+        "Path Pattern: /noexistingpattern", "Arguments:", "- world:anyone:r",
+        "Description: " + String.format(ZKPolicyDefs.Check.DESCRIPTION_FORMAT, "/a", "/noexistingpattern"),
+        "- world:anyone:r", "", "Result: PASS", "No znodes matching the requested path pattern found.",
+        ZKPolicyDefs.TerminalConstants.subSectionSeparator, "", "Overall Check Result: PASS", "");
+
+    assertEquals(expectedOutput, zkAudit.generateChecksSection());
+  }
+
+  @Test
   public void testInvalidRootPathCheck() throws Exception {
     File file = new File(testTempDir, "audit_tmp.yml");
 


### PR DESCRIPTION
To fix #2, either `zkpolicy` allows check declarations without `negate` keys or the documentation (more specifically `audit_example.yaml`) needs fixing. My lucky guess is the former, so here's a patch.

Note to self: Lombok needs bumping to build the project with OpenJDK17.

``` diff
@@ -64,8 +64,8 @@ or submit itself to any jurisdiction.
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <lombok.version>1.18.12</lombok.version>
-    <lombok.maven.plugin.version>1.18.12.0</lombok.maven.plugin.version>
+    <lombok.version>1.18.22</lombok.version>
+    <lombok.maven.plugin.version>1.18.20.0</lombok.maven.plugin.version>
     <picocli.version>4.5.0</picocli.version>
   </properties>
   <dependencies>
```

Closes #2.
